### PR TITLE
feat: Meal warning message changes according to length of stay

### DIFF
--- a/src/components/specialQuestions/plats/DishesNumberInfo.tsx
+++ b/src/components/specialQuestions/plats/DishesNumberInfo.tsx
@@ -1,5 +1,4 @@
 import Trans from '@/components/translation/Trans'
-import Emoji from '@/design-system/utils/Emoji'
 import { useRule } from '@/publicodes-state'
 
 export default function DishesNumberInfo() {
@@ -7,28 +6,30 @@ export default function DishesNumberInfo() {
     'ui . nombre de repas par semaine'
   )
 
+  const travelTimeRule = useRule('transport . voyageurs . duree')
+
   return (
     <>
       <div aria-live="polite" className="mb-2 text-center text-sm">
-        {totalNumberOfPlats !== 14 ? (
+        {travelTimeRule.value && (
           <span className="text-red-700">
-            <Trans>Vous avez sélectionné</Trans>{' '}
-            <strong>{totalNumberOfPlats}</strong>{' '}
+            <Trans>Vous avez dit rester </Trans>
             <strong>
-              <Trans>repas</Trans>
+              <strong>{+travelTimeRule.value}</strong>{' '}
             </strong>{' '}
-            <Trans>sur les 14 habituels</Trans> <Emoji>🍽️</Emoji>
-          </span>
-        ) : null}
-        {totalNumberOfPlats === 14 ? (
-          <span>
-            <strong>{totalNumberOfPlats}</strong>{' '}
+            <Trans>jours, êtes vous sûr de vouloir renseigner </Trans>
             <strong>
-              <Trans>repas</Trans>
+              <strong>
+                {totalNumberOfPlats < 2 * +travelTimeRule.value
+                  ? `moins de ${2 * +travelTimeRule.value}`
+                  : `plus de ${2 * +travelTimeRule.value}`}
+              </strong>{' '}
             </strong>{' '}
-            <Trans>par semaine, miam</Trans> <Emoji>😋</Emoji>
+            <Trans>
+              repas (soit {totalNumberOfPlats < 2 * +travelTimeRule.value ? 'moins' : 'plus'} de 2 repas par jour).
+            </Trans>
           </span>
-        ) : null}
+        )}
       </div>
     </>
   )

--- a/src/components/specialQuestions/plats/DishesNumberInfo.tsx
+++ b/src/components/specialQuestions/plats/DishesNumberInfo.tsx
@@ -11,7 +11,7 @@ export default function DishesNumberInfo() {
   return (
     <>
       <div aria-live="polite" className="mb-2 text-center text-sm">
-        {travelTime !== 0 && (
+        {travelTime !== 0 && totalNumberOfPlats !== 2 * travelTime && (
           <span className="text-red-700">
             <Trans>Vous avez dit rester </Trans>
             <strong>

--- a/src/components/specialQuestions/plats/DishesNumberInfo.tsx
+++ b/src/components/specialQuestions/plats/DishesNumberInfo.tsx
@@ -6,27 +6,27 @@ export default function DishesNumberInfo() {
     'ui . nombre de repas par semaine'
   )
 
-  const travelTimeRule = useRule('transport . voyageurs . duree')
+  const { numericValue: travelTime = 0 } = useRule('transport . voyageurs . duree') ?? {};
 
   return (
     <>
       <div aria-live="polite" className="mb-2 text-center text-sm">
-        {travelTimeRule.value && (
+        {travelTime !== 0 && (
           <span className="text-red-700">
             <Trans>Vous avez dit rester </Trans>
             <strong>
-              <strong>{+travelTimeRule.value}</strong>{' '}
+              <strong>{travelTime}</strong>{' '}
             </strong>{' '}
             <Trans>jours, êtes vous sûr de vouloir renseigner </Trans>
             <strong>
               <strong>
-                {totalNumberOfPlats < 2 * +travelTimeRule.value
-                  ? `moins de ${2 * +travelTimeRule.value}`
-                  : `plus de ${2 * +travelTimeRule.value}`}
+                {totalNumberOfPlats < 2 * travelTime
+                  ? `moins de ${2 * travelTime}`
+                  : `plus de ${2 * travelTime}`}
               </strong>{' '}
             </strong>{' '}
             <Trans>
-              repas (soit {totalNumberOfPlats < 2 * +travelTimeRule.value ? 'moins' : 'plus'} de 2 repas par jour).
+              repas (soit {totalNumberOfPlats < 2 * travelTime ? 'moins' : 'plus'} de 2 repas par jour).
             </Trans>
           </span>
         )}


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----

- Changer le message d'information du nombre de plats en fonction d'une quesiton crée et posée précédemment. 

:watermelon: Implémentation
----

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)