### PR TITLE
feat: Add dependant question for conditional title and description

### DIFF
--- a/src/components/form/Question.tsx
+++ b/src/components/form/Question.tsx
@@ -58,11 +58,9 @@ export default function Question({
     warning,
     questionPassee,
     descriptionPassee,
-    questionDependante
   } = useRule(question)
 
-  //TODO: A voir pour conditionner la regle
-  const dependanteRule = useRule(questionDependante || '');
+  const dependanteRule = useRule('transport . passé');
 
   const isPast = dependanteRule?.value || false;
 

--- a/src/components/form/Question.tsx
+++ b/src/components/form/Question.tsx
@@ -56,10 +56,26 @@ export default function Question({
     activeNotifications,
     plancher,
     warning,
+    questionPassee,
+    descriptionPassee,
+    questionDependante
   } = useRule(question)
 
-  // It should happen only on mount (the component remount every time the question changes)
-  const prevQuestion = useRef('')
+  //TODO: A voir pour conditionner la regle
+  const dependanteRule = useRule(questionDependante || '');
+
+  const isPast = dependanteRule?.value || false;
+
+  let questionLabel = label;
+  let questionDescription = description;
+
+  if (isPast && questionPassee && descriptionPassee) {
+    questionLabel = questionPassee;
+    questionDescription = descriptionPassee;
+  }
+
+  // Hook non conditionnel
+  const prevQuestion = useRef('');
 
   useEffect(() => {
     if (type !== 'number') {
@@ -79,7 +95,7 @@ export default function Question({
     <>
       <div className={twMerge('mb-6 flex flex-col items-start', className)}>
         <Category question={question} />
-        <Label question={question} label={label} description={description} />
+        <Label question={question} label={questionLabel} description={questionDescription} />
 
         <Suggestions
           question={question}

--- a/src/publicodes-state/hooks/useRule/index.ts
+++ b/src/publicodes-state/hooks/useRule/index.ts
@@ -90,7 +90,6 @@ export default function useRule(
     actions,
     questionPassee,
     descriptionPassee,
-    questionDependante
   } = useContent({
     dottedName,
     rule,
@@ -239,9 +238,5 @@ export default function useRule(
      * A different description used in certain cases
      */
     descriptionPassee,
-    /**
-     * Question on which current question depends to display or not Pass question and past description
-     */
-    questionDependante,
   }
 }

--- a/src/publicodes-state/hooks/useRule/index.ts
+++ b/src/publicodes-state/hooks/useRule/index.ts
@@ -88,6 +88,9 @@ export default function useRule(
     suggestions,
     excerpt,
     actions,
+    questionPassee,
+    descriptionPassee,
+    questionDependante
   } = useContent({
     dottedName,
     rule,
@@ -228,5 +231,17 @@ export default function useRule(
      * A list of actions linked to the rules (only used by "ui . pédagogie" rules)
      */
     actions,
+    /**
+     * A different question used in certain cases
+     */
+    questionPassee,
+    /**
+     * A different description used in certain cases
+     */
+    descriptionPassee,
+    /**
+     * Question on which current question depends to display or not Pass question and past description
+     */
+    questionDependante,
   }
 }

--- a/src/publicodes-state/hooks/useRule/useContent.ts
+++ b/src/publicodes-state/hooks/useRule/useContent.ts
@@ -50,6 +50,22 @@ export default function useContent({ dottedName, rule }: Props) {
     [rule]
   )
 
+  const questionPassee = useMemo<DottedName | undefined>(
+    () => rule?.rawNode['question-passee'],
+    [rule]
+  )
+
+  const descriptionPassee = useMemo<DottedName | undefined>(
+    () => rule?.rawNode['description-passee'],
+    [rule]
+  )
+
+  const questionDependante = useMemo<DottedName | undefined>(
+    () => rule?.rawNode['question-dependante'] as DottedName,
+    [rule]
+  )
+
+
   const plancher = useMemo<number>(() => rule?.rawNode['plancher'] ?? 0, [rule])
 
   const warning = useMemo<string | undefined>(
@@ -104,5 +120,8 @@ export default function useContent({ dottedName, rule }: Props) {
     plancher,
     warning,
     actions,
+    questionPassee,
+    descriptionPassee,
+    questionDependante
   }
 }

--- a/src/publicodes-state/hooks/useRule/useContent.ts
+++ b/src/publicodes-state/hooks/useRule/useContent.ts
@@ -60,12 +60,6 @@ export default function useContent({ dottedName, rule }: Props) {
     [rule]
   )
 
-  const questionDependante = useMemo<DottedName | undefined>(
-    () => rule?.rawNode['question-dependante'] as DottedName,
-    [rule]
-  )
-
-
   const plancher = useMemo<number>(() => rule?.rawNode['plancher'] ?? 0, [rule])
 
   const warning = useMemo<string | undefined>(
@@ -121,7 +115,6 @@ export default function useContent({ dottedName, rule }: Props) {
     warning,
     actions,
     questionPassee,
-    descriptionPassee,
-    questionDependante
+    descriptionPassee
   }
 }


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----

- Pouvoir conditionner un titre et une description de question en fonction d'une autre question

:watermelon: Implémentation
----

- Création de trois nouveaux champs côté model
- Lecture de la règle parente et conditonnement en fonction

⚠️ Je n'ai pas réussi à conditionner le useRule. On ne peut pas conditionner un hook. Ca entraine plein de warning dans la console car par défaut la règle est '' donc introuvable. Je n'ai pas eu le temps de creuser plus.

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)