### PR TITLE
feat: Add details of journeys during the vacation period

### DIFF
--- a/src/components/specialQuestions/index.tsx
+++ b/src/components/specialQuestions/index.tsx
@@ -39,6 +39,13 @@ const specialQuestions: Record<string, any> = {
       {...props}
     />
   ),
+  'transport . séjour . voiture . km': (props: Props) => (
+    <Voiture
+      key="transport . séjour . voiture . km"
+      question="transport . séjour . voiture . km"
+      {...props}
+    />
+  ),
 }
 
 export default specialQuestions


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----

Le modèle du poste Transport fait qu'on questionne deux fois les km parcourus car on considère deux types de trajets différents (A-R domicile/lieu de séjour ; pendant le séjour)

Pour l'instant la première question sur les km parcourus (celle portant sur l'A-R) propose l'option "détailler mes trajets" et il faudrait aussi qu'elle existe pour la deuxième question sur les km parcourus (celle des kms pendant le séjour).

:watermelon: Implémentation
----

- Dans les questions spéciales, j'ai dupiqué ce qui avait été utilisé pour le transport des voitures. 
- Utilisation du composant Voiture

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)