### PR TITLE
feat: Images added to 'logement' and 'divers' transition pages

### DIFF
--- a/src/app/(simulation)/(large-layout-nosticky)/fin/page.tsx
+++ b/src/app/(simulation)/(large-layout-nosticky)/fin/page.tsx
@@ -42,7 +42,7 @@ export default function FinPage() {
 
   return (
     <div className="relative">
-      <ImpactCO2Module src="https://impactco2.fr/iframe.js" dataType="quiz" dataSearch="?&language=fr&theme=default" name="impact-co2" title=""/>
+      <ImpactCO2Module src="https://impactco2.fr/iframe.js" dataType="quiz" dataSearch="?&language=fr&theme=default" name="impact-co2"/>
       <IframeDataShareModal />
 
       <Poll />

--- a/src/app/_components/transition/page.tsx
+++ b/src/app/_components/transition/page.tsx
@@ -32,6 +32,32 @@ export const TransitionPage = ({ transitionPage }: { transitionPage: string }) =
                 title="Quelques ordres de grandeur pour comparaison :"
               />
             );
+          case 'logement':
+            return (
+              <div>
+                <div>Quelques ordres de grandeur pour comparaison</div>
+                <div style={{ marginTop: '20px', textAlign: 'center' }}>
+                  <img
+                    src="/images/illustrations/logement.png"
+                    alt=""
+                    style={{ maxWidth: '100%', height: 'auto' }}
+                  />
+                </div>
+              </div>
+            )
+          case 'divers':
+            return (
+              <div>
+                <div>Quelques ordres de grandeur pour comparaison</div>
+                <div style={{ marginTop: '20px', textAlign: 'center' }}>
+                  <img
+                    src="/images/illustrations/divers.png"
+                    alt=""
+                    style={{ maxWidth: '100%', height: 'auto' }}
+                  />
+                </div>
+              </div>
+            )
           default:
             return <div>{title}</div>;
         }

--- a/src/app/_components/transition/page.tsx
+++ b/src/app/_components/transition/page.tsx
@@ -10,6 +10,7 @@ export const TransitionPage = ({ transitionPage }: { transitionPage: string }) =
 
   return (
     <div>
+      <div>Quelques ordres de grandeur pour comparaison :</div>
       {(() => {
         switch (transitionPage) {
           case 'transport':
@@ -19,7 +20,6 @@ export const TransitionPage = ({ transitionPage }: { transitionPage: string }) =
                 dataType="transport"
                 dataSearch="?theme=default&language=fr&km=100&defaultMode=list"
                 name="impact-co2"
-                title="Quelques ordres de grandeur pour comparaison :"
               />
             );
           case 'alimentation':
@@ -29,13 +29,11 @@ export const TransitionPage = ({ transitionPage }: { transitionPage: string }) =
                 dataType="/alimentation"
                 dataSearch="?alimentationCategory=group&theme=default&language=fr"
                 name="impact-co2"
-                title="Quelques ordres de grandeur pour comparaison :"
               />
             );
           case 'logement':
             return (
               <div>
-                <div>Quelques ordres de grandeur pour comparaison</div>
                 <div style={{ marginTop: '20px', textAlign: 'center' }}>
                   <img
                     src="/images/illustrations/logement.png"
@@ -48,7 +46,6 @@ export const TransitionPage = ({ transitionPage }: { transitionPage: string }) =
           case 'divers':
             return (
               <div>
-                <div>Quelques ordres de grandeur pour comparaison</div>
                 <div style={{ marginTop: '20px', textAlign: 'center' }}>
                   <img
                     src="/images/illustrations/divers.png"

--- a/src/components/encapsulage/ImpactCO2Module.tsx
+++ b/src/components/encapsulage/ImpactCO2Module.tsx
@@ -5,15 +5,13 @@ interface ImpactCO2ModuleProps {
   dataType: string;
   dataSearch: string;
   name: string;
-  title: string;
 }
 
 export const ImpactCO2Module = ({
                                 src,
                                 dataType,
                                 dataSearch,
-                                name,
-                                title }: ImpactCO2ModuleProps) => {
+                                name }: ImpactCO2ModuleProps) => {
 
   useEffect(() => {
     const script = document.createElement('script');
@@ -39,7 +37,6 @@ export const ImpactCO2Module = ({
 
   return (
     <div>
-      <div>{title}</div>
       <div id="impact-co2-container"></div>
     </div>
   );


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----

Pour ces deux postes, il n'y a pas d'outil impact CO2. On va donc faire des infographies maisons que l'on affichera ici. Cependant, comme celles-ci ne sont pas encore faites, pour l'instant, afficher les images des postes (celle présente en bas à droite pour chaque poste)

:watermelon: Implémentation
----

- Dans le switch/case des pages de transition, ajouter deux cas pour le logement et divers afin d'y ajouter des images

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)