### PR TITLE
Feature/#43 modifier les infos sur le total de co2

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -25,7 +25,6 @@ import { usePathname } from 'next/navigation'
 import { twMerge } from 'tailwind-merge'
 import Link from '../Link'
 import Logo from '../misc/Logo'
-import LanguageSwitchButton from '../translation/LanguageSwitchButton'
 import Trans from '../translation/Trans'
 
 export default function Footer({ className = '' }) {

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -152,11 +152,8 @@ export default function Footer({ className = '' }) {
 
           <div className="flex flex-wrap justify-between gap-8 md:flex-row md:flex-nowrap">
             <div>
-              <div className="mt-6 flex flex-wrap items-start justify-between gap-10">
-                <LanguageSwitchButton />
-              </div>
 
-              <div className="mt-4 text-xs">
+              <div className="mt-10 text-xs">
                 <InlineLink
                   href="/accessibilite"
                   className="text-default no-underline hover:underline">

--- a/src/components/total/Total.tsx
+++ b/src/components/total/Total.tsx
@@ -17,6 +17,7 @@ import Explanation from './total/Explanation'
 import Progress from './total/Progress'
 import TotalButtons from './total/TotalButtons'
 import TotalFootprintNumber from './total/TotalFootprintNumber'
+import { useRouter } from 'next/navigation'
 
 export default function Total({
   toggleQuestionList,
@@ -34,6 +35,8 @@ export default function Total({
   const { progression } = useCurrentSimulation()
 
   const { currentCategory } = useForm()
+
+  const router = useRouter()
 
   const [hasManuallyOpenedTutorial, setHasManuallyOpenedTutorial] =
     useState(false)
@@ -80,7 +83,7 @@ export default function Total({
 
         <div className="mb-0 flex w-full max-w-6xl justify-between overflow-visible pl-1 pr-4 lg:mx-auto lg:px-4">
           <div className="relative flex items-center gap-1 lg:gap-4">
-            {simulationMode && <ButtonBack onClick={toggleSaveModal} />}
+            {simulationMode && <ButtonBack onClick={() => router.push('/')} />}
 
             <TotalFootprintNumber />
 

--- a/src/components/total/total/Explanation.tsx
+++ b/src/components/total/total/Explanation.tsx
@@ -1,11 +1,9 @@
 'use client'
 
-import Link from '@/components/Link'
 import Trans from '@/components/translation/Trans'
 import Button from '@/design-system/inputs/Button'
 import Badge from '@/design-system/layout/Badge'
 import { useClientTranslation } from '@/hooks/useClientTranslation'
-import { useCurrentSimulation } from '@/publicodes-state'
 import { motion } from 'framer-motion'
 import { useEffect, useState } from 'react'
 
@@ -16,7 +14,6 @@ export default function Explanation({
   toggleOpen: () => void
   isFirstToggle: boolean
 }) {
-  const { progression } = useCurrentSimulation()
 
   const { t } = useClientTranslation()
 

--- a/src/components/total/total/Explanation.tsx
+++ b/src/components/total/total/Explanation.tsx
@@ -63,41 +63,20 @@ export default function Explanation({
         </button>
       </div>
 
-      {progression === 0 ? (
-        <p className="mb-2">
-          <Trans i18nKey={'components.ScoreExplanation.text.p1'}>
-            🧮 Voici votre score de départ, calculé à partir de réponses
-            attribuées à l'avance à chaque question ! Il évoluera à chaque
-            nouvelle réponse.
-          </Trans>
-        </p>
-      ) : (
-        <p className="mb-2">
-          <Trans i18nKey={'components.ScoreExplanation.text.p2'}>
-            🧮 Voici votre score provisoire, il évolue à chaque nouvelle réponse
-            !
-          </Trans>
-        </p>
-      )}
       <p className="mb-2">
-        <Trans i18nKey={'components.ScoreExplanation.text.p3'}>
-          🤔 Si vous répondez "je ne sais pas" à une question, le score ne
-          changera pas : une valeur par défaut vous est attribuée.
+        <Trans i18nKey={'components.ScoreExplanation.text.p1'}>
+          🧮 Voici votre empreinte provisoire, elle évolue à chaque nouvelle réponse.
         </Trans>
       </p>
       <p className="mb-2">
-        <Trans i18nKey={'components.ScoreExplanation.text.p4'}>
-          💡 Nous améliorons le calcul et ses valeurs par défaut{' '}
-          <Link href="/nouveautes">tous les mois</Link>!
+        <Trans i18nKey={'components.ScoreExplanation.text.p3'}>
+          🤔 Si vous passez une question, l’empreinte ne changera pas : une empreinte par défaut sera attribuée.
         </Trans>
       </p>
       <p className="mb-2 md:mb-4">
         <Badge tag="span" color="secondary" size="xs">
           BETA
         </Badge>{' '}
-        <Trans>
-          Retrouvez aussi le résultat de votre empreinte eau à la fin du test !
-        </Trans>
       </p>
       <div className="flex justify-end">
         <Button

--- a/src/components/total/total/TotalButtons.tsx
+++ b/src/components/total/total/TotalButtons.tsx
@@ -32,7 +32,7 @@ export default function TotalButtons({
           <Trans>Liste des questions</Trans>
         </span>
       </Button>
-      {toggleSaveModal ? (
+      {/*{toggleSaveModal ? (
         <Button
           color="text"
           size="sm"
@@ -49,7 +49,7 @@ export default function TotalButtons({
             <Trans>Reprendre plus tard</Trans>
           </span>
         </Button>
-      ) : null}
+      ) : null}*/}
     </div>
   )
 }

--- a/src/components/total/total/TotalButtons.tsx
+++ b/src/components/total/total/TotalButtons.tsx
@@ -1,11 +1,8 @@
 'use client'
 
 import ListIcon from '@/components/icons/ListIcon'
-import SaveCheckIcon from '@/components/icons/SaveCheckIcon'
-import SaveIcon from '@/components/icons/SaveIcon'
 import Trans from '@/components/translation/Trans'
 import Button from '@/design-system/inputs/Button'
-import { useCurrentSimulation } from '@/publicodes-state'
 
 type Props = {
   toggleQuestionList: () => void
@@ -14,9 +11,7 @@ type Props = {
 
 export default function TotalButtons({
   toggleQuestionList,
-  toggleSaveModal,
 }: Props) {
-  const { savedViaEmail } = useCurrentSimulation()
 
   return (
     <div className="flex">

--- a/src/locales/ui/ui-fr.yaml
+++ b/src/locales/ui/ui-fr.yaml
@@ -62,9 +62,9 @@ entries:
   Une technologie moderne: Une technologie moderne
   Vous n'avez pas encore fait le test.: Vous n'avez pas encore fait le test.
   actions choisies: actions choisies
-  components.ScoreExplanation.text.p1: 🧮 Voici votre score de départ, calculé à partir de réponses attribuées à l'avance à chaque question ! Il évoluera à chaque nouvelle réponse.
+  components.ScoreExplanation.text.p1: 🧮 Voici votre empreinte provisoire, elle évolue à chaque nouvelle réponse.
   components.ScoreExplanation.text.p2: 🧮 Voici votre score provisoire, il évolue à chaque nouvelle réponse !
-  components.ScoreExplanation.text.p3: '🤔 Si vous répondez "je ne sais pas" à une question, le score ne changera pas : une valeur par défaut vous est attribuée.'
+  components.ScoreExplanation.text.p3: '🤔 Si vous passez une question, l’empreinte ne changera pas : une empreinte par défaut sera attribuée.'
   components.ScoreExplanation.text.p4: 💡 Nous améliorons le calcul et ses valeurs par défaut <2>tous les mois</2>!
   components.localisation.Localisation.warnMessage: Pour le moment, il n'existe pas de modèle de calcul pour {{countryName}}, le modèle Français vous est proposé par défaut.
   components.localisation.Localisation.warnMessage2: Nous n'avons pas pu détecter votre pays de simulation, le modèle Français vous est proposé par défaut.


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----

### Wording : 
- Remplacer « Voici votre score […] »  Voici votre empreinte provisoire, elle évolue à chaque nouvelle réponse
- Remplacer « Si vous répondez je ne sais pas […]  Si vous passez une question, l’empreinte ne changera pas : une empreinte par défaut sera attribuée
- Supprimer :
o Nous améliorons le calcul et ses valeurs par défaut tous les mois !
o Retrouvez aussi le résultat de votre empreinte eau à la fin du test

### Retrait d'éléments 
- Masquer la possibilité de reprendre le test plus tard (mais ne pas supprimer le code, c'est possible qu'on en ait besoin à un moment)
- (**BONUS**) Retrait des boutons pour changer de langue

###
:watermelon: Implémentation
----

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)