### PR TITLE
Affichage valeur d'empreinte en direct

### DIFF
--- a/src/components/total/Total.tsx
+++ b/src/components/total/Total.tsx
@@ -11,7 +11,6 @@ import { useCurrentSimulation, useForm, useUser } from '@/publicodes-state'
 import { trackEvent } from '@/utils/matomo/trackEvent'
 import { useEffect, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
-import ValueChangeDisplay from '../misc/ValueChangeDisplay'
 import ButtonBack from './total/ButtonBack'
 import Explanation from './total/Explanation'
 import Progress from './total/Progress'
@@ -100,13 +99,13 @@ export default function Total({
           ) : null}
         </div>
 
-        <div
+        {/*<div
           className="absolute -bottom-7 left-10 w-full lg:left-4"
           aria-live="polite">
           <div className="w-full max-w-6xl md:mx-auto">
             <ValueChangeDisplay />
           </div>
-        </div>
+        </div>*/}
       </div>
       {!tutorials.scoreExplanation && simulationMode ? (
         <div className="relative mx-auto max-w-6xl">

--- a/src/components/total/total/TotalFootprintNumber.tsx
+++ b/src/components/total/total/TotalFootprintNumber.tsx
@@ -12,7 +12,7 @@ type Props = {
 }
 
 const duration = {
-  carbone: <Trans>de CO₂e par an</Trans>,
+  carbone: <Trans>de CO₂e par séjour</Trans>,
   eau: <Trans>d'eau par jour</Trans>,
 }
 export default function TotalFootprintNumber({


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----

- Retrait de l'affichage carbone en direct
- Remplacement de "An" par "Séjour"

:watermelon: Implémentation
----



:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)