### PR TITLE
Feature/#68 comaprateur onglets

### DIFF
--- a/src/app/(simulation)/(large-layout-nosticky)/fin/page.tsx
+++ b/src/app/(simulation)/(large-layout-nosticky)/fin/page.tsx
@@ -8,7 +8,6 @@ import { carboneMetric, eauMetric } from '@/constants/metric'
 import Title from '@/design-system/layout/Title'
 import { useEndGuard } from '@/hooks/navigation/useEndGuard'
 import { useSimulationIdInQueryParams } from '@/hooks/simulation/useSimulationIdInQueryParams'
-import { useCurrentMetric } from '@/hooks/useCurrentMetric'
 import { Metric } from '@/publicodes-state/types'
 import { ReactElement } from 'react'
 import { twMerge } from 'tailwind-merge'
@@ -27,7 +26,7 @@ export default function FinPage() {
 
   const { simulationIdInQueryParams } = useSimulationIdInQueryParams()
 
-  const { currentMetric } = useCurrentMetric()
+  const currentMetric = "carbone"
 
   // If the simulationIdInQueryParams is set, it means that the simulation is not loaded yet
   if (!isGuardInit || isGuardRedirecting || !!simulationIdInQueryParams)
@@ -66,7 +65,7 @@ export default function FinPage() {
                 {titles[currentMetric]}
               </strong>
             </Title>
-            <CategoriesAccordion metric={currentMetric} />
+            <CategoriesAccordion metric="carbone" />
           </div>
 
           <ShareBlock />

--- a/src/components/fin/MetricSlider.tsx
+++ b/src/components/fin/MetricSlider.tsx
@@ -5,6 +5,7 @@ import CarboneTotalChart from './metricSlider/CarboneTotalChart'
 import { ImpactCO2Module } from '@/components/encapsulage/ImpactCO2Module'
 import TabNavigation from '@/components/fin/metricSlider/TabNavigation'
 import { carboneTab, comparateurTab } from '@/constants/tabs'
+import { useRule } from '@/publicodes-state'
 
 type Props = {
   carboneTotal?: number
@@ -47,6 +48,8 @@ export default function MetricSlider({
     }
   }, [isStatic])
 
+  const { numericValue } = useRule('bilan')
+  const usedValue = carboneTotal ?? numericValue
 
   return (
     <div
@@ -82,7 +85,7 @@ export default function MetricSlider({
             <ImpactCO2Module
               src="https://impactco2.fr/iframe.js"
               dataType="comparateur"
-              dataSearch="?value=100"
+              dataSearch={`?value=${Math.round(Number(usedValue || 0))}`}
               name="impact-co2"
             />
           </div>

--- a/src/components/fin/MetricSlider.tsx
+++ b/src/components/fin/MetricSlider.tsx
@@ -13,9 +13,11 @@ type Props = {
 }
 export default function MetricSlider({
   carboneTotal,
-  isStatic,
+  isStatic: initialIsStatic,
 }: Props) {
   const { currentTab } = useCurrentTab()
+
+  const isStatic = currentTab === comparateurTab || initialIsStatic
 
   const [isSticky, setIsSticky] = useState(false)
 
@@ -44,6 +46,7 @@ export default function MetricSlider({
       window.removeEventListener('scroll', handleScroll)
     }
   }, [isStatic])
+
 
   return (
     <div

--- a/src/components/fin/MetricSlider.tsx
+++ b/src/components/fin/MetricSlider.tsx
@@ -1,8 +1,10 @@
-import { carboneMetric } from '@/constants/metric'
-import { useCurrentMetric } from '@/hooks/useCurrentMetric'
-import { useEffect, useRef, useState } from 'react'
+import { useCurrentTab } from '@/hooks/useCurrentTab'
+import React, { useEffect, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import CarboneTotalChart from './metricSlider/CarboneTotalChart'
+import { ImpactCO2Module } from '@/components/encapsulage/ImpactCO2Module'
+import TabNavigation from '@/components/fin/metricSlider/TabNavigation'
+import { carboneTab, comparateurTab } from '@/constants/tabs'
 
 type Props = {
   carboneTotal?: number
@@ -13,7 +15,7 @@ export default function MetricSlider({
   carboneTotal,
   isStatic,
 }: Props) {
-  const { currentMetric } = useCurrentMetric()
+  const { currentTab } = useCurrentTab()
 
   const [isSticky, setIsSticky] = useState(false)
 
@@ -46,31 +48,42 @@ export default function MetricSlider({
   return (
     <div
       className={twMerge(
-        isStatic ? '' : 'sticky top-0 z-40 mb-4 h-96',
-        isSticky && 'pointer-events-none'
+        isStatic ? '' : 'sticky top-0 z-40 mb-4',
+        isSticky && 'pointer-events-none',
+        currentTab === carboneTab ? 'h-96' : 'h-[50rem]'
       )}
       ref={myElementRef}>
+      <TabNavigation
+        isSticky={isSticky}
+        isStatic={isStatic}
+        shouldShowWater={!(isStatic)}
+      />
       <div
         className={twMerge(
           'relative mx-auto -mt-0.5 w-full overflow-hidden rounded-b-xl rounded-tr-xl border-2 border-primary-50 bg-gray-100 px-0 transition-all duration-300',
-          isSticky ? 'h-20 lg:h-[5.5rem]' : 'h-72 lg:h-80'
+          isSticky
+            ? 'h-20 lg:h-[5.5rem]'
+            : currentTab === carboneTab
+              ? 'h-72 lg:h-80'
+              : 'h-72 lg:h-[46rem]'
         )}>
-        {currentMetric === carboneMetric && (
+        {currentTab === carboneTab && (
           <div className={twMerge('relative !flex h-full flex-col')}>
             <div className="h-full w-full px-4">
               <CarboneTotalChart isSmall={isSticky} total={carboneTotal} />
             </div>
           </div>
         )}
-        {/* {currentMetric === eauMetric && (
+         {currentTab === comparateurTab && (
           <div className={twMerge('relative !flex h-full flex-col')}>
-            <WaterTotalChart
-              isSmall={isSticky}
-              total={waterTotal}
-              isStatic={isStatic}
+            <ImpactCO2Module
+              src="https://impactco2.fr/iframe.js"
+              dataType="comparateur"
+              dataSearch="?value=100"
+              name="impact-co2"
             />
           </div>
-        )} */}
+        )}
       </div>
     </div>
   )

--- a/src/components/fin/metricSlider/TabNavigation.tsx
+++ b/src/components/fin/metricSlider/TabNavigation.tsx
@@ -16,7 +16,7 @@ const carboneTabClasses: Record<Tab, string> = {
   [carboneTab]: tabSelectedClasses,
   [comparateurTab]: tabNotSelectedClasses,
 }
-const eauTabClasses: Record<Tab, string> = {
+const comparateurTabClasses: Record<Tab, string> = {
   [carboneTab]: tabNotSelectedClasses,
   [comparateurTab]: tabSelectedClasses,
 }
@@ -57,7 +57,7 @@ export default function TabNavigation({
             onClick={() => setCurrentTab(comparateurTab)}
             className={twMerge(
               'relative z-40 mb-0 rounded-t-xl border-2 px-4 pb-1 pt-2 text-lg font-medium transition-all duration-300',
-              eauTabClasses[currentTab]
+              comparateurTabClasses[currentTab]
             )}>
             <span className="hidden lg:inline">
               <Trans>A quoi cela équivaut ?</Trans>{' '}

--- a/src/components/fin/metricSlider/TabNavigation.tsx
+++ b/src/components/fin/metricSlider/TabNavigation.tsx
@@ -52,14 +52,14 @@ export default function TabNavigation({
           </span>
         </button>
         <button
-          aria-label={t('Comparateur Carbone')}
+          aria-label={t('A quoi cela équivaut ?')}
           onClick={() => setCurrentTab(comparateurTab)}
           className={twMerge(
             'relative z-40 mb-0 rounded-t-xl border-2 px-4 pb-1 pt-2 text-lg font-medium transition-all duration-300',
             eauTabClasses[currentTab]
           )}>
           <span className="hidden lg:inline">
-            <Trans>Comparateur Carbone</Trans>{' '}
+            <Trans>A quoi cela équivaut ?</Trans>{' '}
           </span>
         </button>
       </div>

--- a/src/components/fin/metricSlider/TabNavigation.tsx
+++ b/src/components/fin/metricSlider/TabNavigation.tsx
@@ -51,17 +51,19 @@ export default function TabNavigation({
             <Trans>L'empreinte de mon séjour</Trans>{' '}
           </span>
         </button>
-        <button
-          aria-label={t('A quoi cela équivaut ?')}
-          onClick={() => setCurrentTab(comparateurTab)}
-          className={twMerge(
-            'relative z-40 mb-0 rounded-t-xl border-2 px-4 pb-1 pt-2 text-lg font-medium transition-all duration-300',
-            eauTabClasses[currentTab]
-          )}>
-          <span className="hidden lg:inline">
-            <Trans>A quoi cela équivaut ?</Trans>{' '}
-          </span>
-        </button>
+        {!isSticky && (
+          <button
+            aria-label={t('A quoi cela équivaut ?')}
+            onClick={() => setCurrentTab(comparateurTab)}
+            className={twMerge(
+              'relative z-40 mb-0 rounded-t-xl border-2 px-4 pb-1 pt-2 text-lg font-medium transition-all duration-300',
+              eauTabClasses[currentTab]
+            )}>
+            <span className="hidden lg:inline">
+              <Trans>A quoi cela équivaut ?</Trans>{' '}
+            </span>
+          </button>
+        )}
       </div>
       {!isStatic && <HeadingButtons />}
     </div>

--- a/src/components/fin/metricSlider/TabNavigation.tsx
+++ b/src/components/fin/metricSlider/TabNavigation.tsx
@@ -1,34 +1,25 @@
 'use client'
 
-import { carboneMetric, eauMetric } from '@/constants/metric'
-import { useCurrentMetric } from '@/hooks/useCurrentMetric'
-import { Metric } from '@/publicodes-state/types'
 import { twMerge } from 'tailwind-merge'
 import HeadingButtons from './heading/HeadingButtons'
+import Trans from '@/components/translation/Trans'
+import { useClientTranslation } from '@/hooks/useClientTranslation'
+import { useCurrentTab } from '@/hooks/useCurrentTab'
+import { carboneTab, comparateurTab } from '@/constants/tabs'
+import { Tab } from '@/publicodes-state/types'
 
 const tabSelectedClasses =
   'border-x-primary-50 border-b-transparent border-t-primary-50 bg-gray-100'
 const tabNotSelectedClasses =
   'border-transparent border-b-primary-50 text-primary-700'
-const carboneTabClasses: Record<Metric, string> = {
-  [carboneMetric]: tabSelectedClasses,
-  [eauMetric]: tabNotSelectedClasses,
+const carboneTabClasses: Record<Tab, string> = {
+  [carboneTab]: tabSelectedClasses,
+  [comparateurTab]: tabNotSelectedClasses,
 }
-/*
-const eauTabClasses: Record<Metric, string> = {
-  [carboneMetric]: tabNotSelectedClasses,
-  [eauMetric]: tabSelectedClasses,
+const eauTabClasses: Record<Tab, string> = {
+  [carboneTab]: tabNotSelectedClasses,
+  [comparateurTab]: tabSelectedClasses,
 }
-*/
-
-// const carboneLabelClasses: Record<Metric, string> = {
-//   [carboneMetric]: 'font-black text-secondary-700',
-//   [eauMetric]: 'font-medium',
-// }
-/*const eauLabelClasses: Record<Metric, string> = {
-  [carboneMetric]: 'font-medium',
-  [eauMetric]: 'font-black text-secondary-700',
-}*/
 
 type Props = {
   isSticky?: boolean
@@ -39,7 +30,8 @@ export default function TabNavigation({
   isSticky,
   isStatic,
 }: Props) {
-  const { currentMetric, setCurrentMetric } = useCurrentMetric()
+  const { t } = useClientTranslation()
+  const { currentTab, setCurrentTab } = useCurrentTab()
 
   return (
     <div
@@ -50,41 +42,26 @@ export default function TabNavigation({
       <div className="flex">
         <button
           aria-label="L'empreinte de mon séjour"
-          onClick={() => setCurrentMetric(carboneMetric)}
+          onClick={() => setCurrentTab(carboneTab)}
           className={twMerge(
-            // 'z-40 mb-0 rounded-t-xl border-2 px-4 pb-1 pt-2 text-lg font-medium transition-all duration-300',
-            carboneTabClasses[currentMetric]
+            'z-40 mb-0 rounded-t-xl border-2 px-4 pb-1 pt-2 text-lg font-medium transition-all duration-300',
+            carboneTabClasses[currentTab]
           )}>
           <span className="hidden lg:inline">
-            L'empreinte de mon séjour
+            <Trans>L'empreinte de mon séjour</Trans>{' '}
           </span>
         </button>
-        {/*{shouldShowWater && (
-          <button
-            aria-label={t('Mon empreinte eau')}
-            onClick={() => setCurrentMetric(eauMetric)}
-            className={twMerge(
-              'relative z-40 mb-0 rounded-t-xl border-2 px-4 pb-1 pt-2 text-lg font-medium transition-all duration-300',
-              eauTabClasses[currentMetric]
-            )}>
-            <span className="hidden lg:inline">
-              <Trans>Mon empreinte</Trans>{' '}
-            </span>
-            <strong
-              className={twMerge(
-                'capitalize lg:normal-case',
-                eauLabelClasses[currentMetric]
-              )}>
-              <Trans>eau</Trans>
-            </strong>
-            <Badge
-              size="xs"
-              color="secondary"
-              className="absolute bottom-full left-full -translate-x-6 translate-y-3 ">
-              BETA
-            </Badge>
-          </button>
-        )}*/}
+        <button
+          aria-label={t('Comparateur Carbone')}
+          onClick={() => setCurrentTab(comparateurTab)}
+          className={twMerge(
+            'relative z-40 mb-0 rounded-t-xl border-2 px-4 pb-1 pt-2 text-lg font-medium transition-all duration-300',
+            eauTabClasses[currentTab]
+          )}>
+          <span className="hidden lg:inline">
+            <Trans>Comparateur Carbone</Trans>{' '}
+          </span>
+        </button>
       </div>
       {!isStatic && <HeadingButtons />}
     </div>

--- a/src/constants/tabs.ts
+++ b/src/constants/tabs.ts
@@ -1,0 +1,9 @@
+import { Tab } from '@/publicodes-state/types'
+
+export const carboneTab = 'carbone' as const
+
+export const comparateurTab = 'comparateur' as const
+
+export const tabs: Tab[] = [carboneTab, comparateurTab]
+
+export const defaultTab: Tab = carboneTab

--- a/src/hooks/useCurrentTab.ts
+++ b/src/hooks/useCurrentTab.ts
@@ -1,0 +1,27 @@
+import { defaultTab, tabs } from '@/constants/tabs'
+import { useQueryParams } from '@/hooks/useQueryParams'
+import { Tab } from '@/publicodes-state/types'
+import { useCallback } from 'react'
+
+const tabParamsName = 'tab'
+
+export function useCurrentTab() {
+  const { queryParams, setQueryParams } = useQueryParams()
+
+  const queryParamsTab = queryParams.get(tabParamsName) as Tab | null
+
+  const setCurrentTab = useCallback(
+    (tab: Tab) => {
+      setQueryParams({ [tabParamsName]: tab })
+    },
+    [setQueryParams]
+  )
+
+  let currentTab = queryParamsTab || defaultTab
+
+  if (!tabs.includes(currentTab)) {
+    currentTab = defaultTab
+  }
+
+  return { currentTab: currentTab, setCurrentTab: setCurrentTab }
+}

--- a/src/publicodes-state/types.d.ts
+++ b/src/publicodes-state/types.d.ts
@@ -95,6 +95,8 @@ export type LocalStorage = {
 
 export type Metric = Metrics
 
+export type Tab = 'carbone' | 'comparateur'
+
 export type Situation = PublicodesSituation<DottedName>
 
 export type ParsedRules = PublicodesParsedRules<DottedName>


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----

- Séparer l'empreinte du séjour d'un comparateur d'empreinte via un sytème d'onglets

:watermelon: Implémentation
----

- Je me suis basé sur le systeme de Metric en créant des constantes pour gérér l'état des tabs
- J'ai repris les onglets utilisé pour l'eau et l'ai adapté pour notre cas 

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)