### PR TITLE
Feature/#69 affichage empreinte sejour option 2

### DIFF
--- a/src/components/fin/metricSlider/carboneTotalChart/Gauge.tsx
+++ b/src/components/fin/metricSlider/carboneTotalChart/Gauge.tsx
@@ -6,7 +6,7 @@ type Props = {
   isSmall?: boolean
 }
 export default function Gauge({ isSmall }: Props) {
-  let { numericValue } = useRule('bilan')
+  const { numericValue } = useRule('bilan')
 
   const isOutOfRange = numericValue > 12000
 

--- a/src/components/fin/metricSlider/carboneTotalChart/Gauge.tsx
+++ b/src/components/fin/metricSlider/carboneTotalChart/Gauge.tsx
@@ -6,7 +6,7 @@ type Props = {
   isSmall?: boolean
 }
 export default function Gauge({ isSmall }: Props) {
-  const { numericValue } = useRule('bilan')
+  let { numericValue } = useRule('bilan')
 
   const isOutOfRange = numericValue > 12000
 
@@ -39,7 +39,7 @@ export default function Gauge({ isSmall }: Props) {
             'absolute bottom-full right-0 text-xs',
             isSmall && 'opacity-0'
           )}>
-          12
+          1000
         </div>
       ) : null}
     </div>

--- a/src/components/fin/metricSlider/carboneTotalChart/TargetNumber.tsx
+++ b/src/components/fin/metricSlider/carboneTotalChart/TargetNumber.tsx
@@ -1,14 +1,16 @@
-import Trans from '@/components/translation/Trans'
 import { motion } from 'framer-motion'
 import { twMerge } from 'tailwind-merge'
 import Arrow from './Arrow'
-
-const position = (2 / 12) * 100
+import { useRule } from '@/publicodes-state'
 
 type Props = {
   isSmall?: boolean
 }
 export default function TargetNumber({ isSmall }: Props) {
+
+  const { numericValue: travelTime = 0 } = useRule('transport . durée séjour') ?? {};
+  const value = Math.round((9200/365)*travelTime);
+  const position = (value * 100) / 1000
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -20,10 +22,10 @@ export default function TargetNumber({ isSmall }: Props) {
       )}
       style={{ left: `${position}%` }}>
       <div className="absolute top-full mt-1 whitespace-nowrap">
-        <strong className="font-black text-secondary-700">2 tonnes,</strong>
+        <strong className="font-black text-secondary-700">{value} kgCO2e,</strong>
         <br />
         <span>
-          <Trans>l’objectif pour 2050</Trans>
+          l'empreinte moyenne d'un français pour {travelTime} jour
         </span>
       </div>
       <Arrow className="h-4 w-4 rotate-180" />

--- a/src/components/fin/metricSlider/carboneTotalChart/TargetNumber.tsx
+++ b/src/components/fin/metricSlider/carboneTotalChart/TargetNumber.tsx
@@ -25,7 +25,7 @@ export default function TargetNumber({ isSmall }: Props) {
         <strong className="font-black text-secondary-700">{value} kgCO2e,</strong>
         <br />
         <span>
-          l'empreinte moyenne d'un français pour {travelTime} jour
+          l'empreinte moyenne d'un français <br/>dans sa vie quotidienne pour {travelTime} jours
         </span>
       </div>
       <Arrow className="h-4 w-4 rotate-180" />

--- a/src/components/fin/metricSlider/carboneTotalChart/TotalNumber.tsx
+++ b/src/components/fin/metricSlider/carboneTotalChart/TotalNumber.tsx
@@ -33,7 +33,7 @@ type Props = {
 export default function TotalNumber({ total, isSmall }: Props) {
   const { t } = useClientTranslation()
 
-  const { numericValue } = useRule('bilan')
+  let { numericValue } = useRule('bilan')
 
   const usedValue = total ?? numericValue
 
@@ -42,7 +42,7 @@ export default function TotalNumber({ total, isSmall }: Props) {
     localize: false,
   })
 
-  const originPosition = (usedValue / 1000 / 12) * 100
+  const originPosition = (usedValue / 1000) * 100
 
   const position = useMemo(() => {
     if (originPosition <= 0) {
@@ -88,7 +88,7 @@ export default function TotalNumber({ total, isSmall }: Props) {
         </span>
         <br />
         <span className="text-lg lg:text-xl">
-          <Trans>de</Trans> CO₂e <Trans>par an</Trans>
+          <Trans>de</Trans> CO₂e
         </span>
       </div>
       <Arrow

--- a/src/components/fin/metricSlider/carboneTotalChart/TotalNumber.tsx
+++ b/src/components/fin/metricSlider/carboneTotalChart/TotalNumber.tsx
@@ -33,7 +33,7 @@ type Props = {
 export default function TotalNumber({ total, isSmall }: Props) {
   const { t } = useClientTranslation()
 
-  let { numericValue } = useRule('bilan')
+  const { numericValue } = useRule('bilan')
 
   const usedValue = total ?? numericValue
 


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----

- On garde la frise et la borne max est fixée à 1000 kg
- On enlève la mention "par an" après CO2e
- On enlève la mention "2 tonnes l’objectif 2050". pour remplacer par "XX, l'empreinte moyenne d'un français pour YY jour"
- Le chiffre XX est calculé de la manière suivante : (9200/365) * durée_séjour et YY = transport . durée_séjour
- On met à droite le Comparateur carbone

:watermelon: Implémentation
----



:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)