### PR TITLE
Feature/add informations to slide card

### DIFF
--- a/config/remoteImagesPatterns.js
+++ b/config/remoteImagesPatterns.js
@@ -29,6 +29,11 @@ const remoteImagesPatterns = [
     port: '',
     pathname: '/**',
   },
+  {
+    protocol: 'https',
+    hostname: 'www.cartograf.fr',
+    pathname: '/regions/hauts-de-france/**',
+  },
 ]
 
 module.exports = remoteImagesPatterns

--- a/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/actions/Card.tsx
+++ b/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/actions/Card.tsx
@@ -11,6 +11,8 @@ type CardProps = {
   category?: string
   isSelected?: boolean
   hide?: boolean
+  description?: string
+  mesure?: string
 }
 
 export default function Card({
@@ -21,6 +23,8 @@ export default function Card({
                                category,
                                isSelected = false,
                                hide = false,
+                               description,
+                                mesure
                              }: CardProps) {
   if (hide) return null
 
@@ -50,6 +54,18 @@ export default function Card({
             {percent || 1} %
           </span>
           <Trans> de votre empreinte</Trans>
+        </div>
+      )}
+      {description !== undefined && (
+        <div className="text-center text-base leading-tight">
+          {description}
+        </div>
+      )}
+      {mesure !== undefined && (
+        <div className="text-center text-base leading-tight">
+          <span className="block text-2xl font-black text-secondary-700">
+            {mesure}
+          </span>
         </div>
       )}
     </div>

--- a/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/actions/Slide.tsx
+++ b/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/actions/Slide.tsx
@@ -11,9 +11,15 @@ type SlideProps = {
 export default function Slide({ ruleName, className, category }: SlideProps) {
   const rule = useRule(ruleName)
   const intensiteCouleur = rule.intensiteCouleur ?? 200
+  let mesure = undefined
+
+  if (rule.value && rule.unite){
+    mesure = rule.value + ' ' + rule.unite
+  }
 
   return (
     <Card
+      icon={rule.icons}
       title={rule.title}
       className={twMerge(
         "min-h-[150px] min-w-[30%] ml-4",
@@ -21,6 +27,8 @@ export default function Slide({ ruleName, className, category }: SlideProps) {
         `bg-${category}-${intensiteCouleur}`,
         className
       )}
+      description={rule.description}
+      mesure={mesure}
     />
   )
 }

--- a/src/publicodes-state/hooks/useRule/index.ts
+++ b/src/publicodes-state/hooks/useRule/index.ts
@@ -93,7 +93,8 @@ export default function useRule(
     descriptionInformations,
     questionPassee,
     descriptionPassee,
-    intensiteCouleur
+    intensiteCouleur,
+    unite
   } = useContent({
     dottedName,
     rule,
@@ -258,5 +259,6 @@ export default function useRule(
      * A description of informations
      */
     descriptionInformations,
+    unite
   }
 }

--- a/src/publicodes-state/hooks/useRule/useContent.ts
+++ b/src/publicodes-state/hooks/useRule/useContent.ts
@@ -106,6 +106,8 @@ export default function useContent({ dottedName, rule }: Props) {
 
   const intensiteCouleur = useMemo<string | undefined>(() => (rule as any)?.rawNode['intensiteCouleur'], [rule])
 
+  const unite = useMemo<string | undefined>(() => (rule as any)?.rawNode['unite'], [rule])
+
   const titreInformations = useMemo<string | undefined>(
     () => (rule as any)?.rawNode['titre-informations'],
     [rule]
@@ -136,6 +138,7 @@ export default function useContent({ dottedName, rule }: Props) {
     questionPassee,
     descriptionPassee,
     intensiteCouleur,
+    unite,
     titreInformations,
     descriptionInformations
   }


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----
- Utilisation des icones et de la description venant du model
- Utilisation de la formule et de l'unité venant du model
- BONUS: J'avais une erreur en lancant le front. Il manquait la référence à cartograf pour l'affichage de l'image

:watermelon: Implémentation
----


:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)
