### PR TITLE
#87 - Add width full for notification markdown

### DIFF
--- a/src/design-system/utils/Markdown.tsx
+++ b/src/design-system/utils/Markdown.tsx
@@ -19,7 +19,7 @@ export default function Markdown({
   ...otherProps
 }: MarkdownProps) {
   return (
-    <div className="markdown">
+    <div className="markdown w-full">
       <MarkdownToJsx
         {...otherProps}
         options={{


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----
-  Ajout du width à 100% pour les notifications
- Ticket numero [87](https://github.com/ABC-TransitionBasCarbone/calculateur-tourisme-front/issues/87)

:watermelon: Implémentation
----

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)