### PR TITLE
85 - Center single or two slides in carousel

### DIFF
--- a/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/actions/Carousel.tsx
+++ b/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/actions/Carousel.tsx
@@ -46,7 +46,10 @@ export default function Carousel({ informations, category }: Props) {
       {informations && informations.length > 0 && (
         <div>
           <div className="relative overflow-hidden w-full p-4" ref={emblaRef}>
-            <div className="flex flew-nowrap">
+            <div className={twMerge(
+              "flex flex-nowrap",
+              informations.length < 3 ? "justify-center" : ""
+            )}>
               {informations.map((ruleName) => (
                 <Slide key={ruleName} ruleName={ruleName} category={category} />
               ))}


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----
-  Ajout du width à 100% pour les notifications
- Ticket numero [85](https://github.com/ABC-TransitionBasCarbone/calculateur-tourisme-front/issues/85)

:watermelon: Implémentation
----

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)