### PR TITLE
feat: Show actions without formules

### DIFF
--- a/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/Subcategory.tsx
+++ b/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/Subcategory.tsx
@@ -37,7 +37,7 @@ export default function Subcategory({ subcategory, index }: Props) {
         </div>
         <Emoji className="text-4xl lg:text-6xl">{icons?.slice(0, 2)}</Emoji>
       </div>
-      <Actions subcategory={subcategory} />
+      <Actions subcategory={subcategory}  noNumberedFootprint/>
     </div>
   )
 }

--- a/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/actions/Action.tsx
+++ b/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/actions/Action.tsx
@@ -39,6 +39,7 @@ export default function Action({
       percent={!hasNoValue ? percent : undefined}
       category={category}
       isSelected={isActionChoosen}
+      showPercentFallback
       className={twMerge(
         colorClassName[index],
         isActionChoosen

--- a/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/actions/Card.tsx
+++ b/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/actions/Card.tsx
@@ -13,6 +13,7 @@ type CardProps = {
   hide?: boolean
   description?: string
   mesure?: string
+  showPercentFallback?: boolean
 }
 
 export default function Card({
@@ -24,7 +25,8 @@ export default function Card({
   isSelected = false,
   hide = false,
   description,
-  mesure
+  mesure,
+  showPercentFallback = false
 }: CardProps) {
   if (hide) return null
 
@@ -48,14 +50,22 @@ export default function Card({
           <Markdown>{title ?? ''}</Markdown>
         </div>
       </div>
-      {percent !== undefined && (
-        <div className="text-center text-base leading-tight">
-          <Markdown className="block text-2xl font-black text-secondary-700">
-            {percent.toString()}
-          </Markdown>
-          <Markdown> % de votre empreinte</Markdown>
-        </div>
-      )}
+      <div className="text-center text-base leading-tight">
+        {percent !== undefined ? (
+          <div className="text-center text-base leading-tight">
+            <Markdown className="block text-2xl font-black text-secondary-700">
+              {percent.toString()}
+            </Markdown>
+            <Markdown> % de votre empreinte</Markdown>
+          </div>
+        ) : showPercentFallback ? (
+          <div className="text-center text-base leading-tight">
+            <Markdown className="block text-2xl font-black text-secondary-700">
+              👏👏👏
+            </Markdown>
+          </div>
+        ) : null}
+      </div>
       {description !== undefined && (
         <Markdown className="text-center text-base leading-tight">
           {description ?? ''}


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----
- Affichage des actions même si elles n'ont pas de formules dans publicodes
- Ticket numero [91](https://github.com/ABC-TransitionBasCarbone/calculateur-tourisme-front/issues/91)

:watermelon: Implémentation
----

- Dans le composant Action, il existait déjà un noNumberedFootprint que j'ai utilisé 
- Grace à ça je récupères toutes les actions
- Le composant Card est utilisé pour les actions et le carousel. Par conséquent j'ai ajouté une propriété `showPercentFallback`  pour ne pas que les 👏👏👏 s'affichent dans les slides

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)