### PR TITLE
Feature/#88 décorelation infos ecran fin

### DIFF
--- a/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/Actions.tsx
+++ b/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/Actions.tsx
@@ -134,7 +134,7 @@ export default function Actions({ subcategory, noNumberedFootprint }: Props) {
       <div className="flex justify-center">
         <Link
           onClick={() => trackEvent(endClickActions)}
-          href="/actions"
+          href={`/actions?catégorie=${category}`}
           className="text-center text-xs">
           <Trans>Voir tous les gestes</Trans> : {customTitle}
         </Link>

--- a/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/Actions.tsx
+++ b/src/app/(simulation)/(large-layout-nosticky)/fin/_components/carbone/subcategories/subcategory/Actions.tsx
@@ -54,6 +54,30 @@ export default function Actions({ subcategory, noNumberedFootprint }: Props) {
 
   const firstThreeActions = sortedActions.slice(0, 3)
 
+  console.log(category)
+  let customTitle = ''
+
+  switch (category) {
+    case 'transport':
+      customTitle = '🚗 Transport'
+      break
+    case 'séjour':
+      customTitle = '🚗 Transport'
+      break
+    case 'alimentation':
+      customTitle = '🍽️ Alimentation'
+      break
+    case 'logement':
+      customTitle = '🏠 Hébergement'
+      break
+    case 'divers':
+      customTitle = '💻 Activités et loisirs'
+      break
+    default:
+      customTitle = '📦 Autre catégorie'
+      break
+  }
+
   return (
     <>
       {!noNumberedFootprint && (
@@ -107,16 +131,14 @@ export default function Actions({ subcategory, noNumberedFootprint }: Props) {
         </motion.div>
       ) : null}
       <Carousel informations={informations} category={category} />
-      {!noNumberedFootprint && (
-        <div className="flex justify-center">
-          <Link
-            onClick={() => trackEvent(endClickActions)}
-            href="/actions"
-            className="text-center text-xs">
-            <Trans>Voir tous les gestes</Trans> : {title}
-          </Link>
-        </div>
-      )}
+      <div className="flex justify-center">
+        <Link
+          onClick={() => trackEvent(endClickActions)}
+          href="/actions"
+          className="text-center text-xs">
+          <Trans>Voir tous les gestes</Trans> : {customTitle}
+        </Link>
+      </div>
     </>
   )
 }


### PR DESCRIPTION
:triangular_flag_on_post: Objectifs
----
- Wording pour les liens vers les actions + affinage des liens
- Ticket numero [88](https://github.com/ABC-TransitionBasCarbone/calculateur-tourisme-front/issues/88)

:watermelon: Implémentation
----

:tada: Axes d'améliorations
----

:ballot_box_with_check: Checklist
----

- [ ] La branche est bien basée sur le dernier commit de [develop](https://danielkummer.github.io/git-flow-cheatsheet/index.fr_FR.html)
- [ ] La [MR](https://docs.gitlab.com/ee/user/project/merge_requests/) est bien à destination de develop
- [ ] Les messages des commits suivent la convention [Git Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html)